### PR TITLE
Fix build by updating usd_python.patch

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -56,7 +56,7 @@ sha256sums=('SKIP'
             'SKIP'
             'SKIP'
             'SKIP'
-            'e737e58d1a3053da16a568e078a25f4f879fda73398475a919f397e5a8fba2a3'
+            'c2db51a83a8d573aa76c760f10e541c84b108d64d05c9647681c4e633b3d0397'
             'd587135fd9b815d60e8b7f48976aa835472922fc8f64c256dc397bfcd3c2642a')
 
 pkgver() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -56,7 +56,7 @@ sha256sums=('SKIP'
             'SKIP'
             'SKIP'
             'SKIP'
-            '333b6fd864d55da2077bc85c55af1a27d4aee9764a1a839df26873a9f19b8703'
+            'e737e58d1a3053da16a568e078a25f4f879fda73398475a919f397e5a8fba2a3'
             'd587135fd9b815d60e8b7f48976aa835472922fc8f64c256dc397bfcd3c2642a')
 
 pkgver() {

--- a/usd_python.patch
+++ b/usd_python.patch
@@ -1,10 +1,10 @@
 diff --git a/build_files/cmake/platform/platform_unix.cmake b/build_files/cmake/platform/platform_unix.cmake
-index bdf39d04d32..4322e0aa042 100644
+index 787d0f87002..659938a45b2 100644
 --- a/build_files/cmake/platform/platform_unix.cmake
 +++ b/build_files/cmake/platform/platform_unix.cmake
-@@ -334,6 +334,10 @@ if(WITH_OPENVDB)
-   endif()
+@@ -329,6 +329,10 @@ if(WITH_OPENVDB)
  endif()
+ add_bundled_libraries(openvdb/lib)
  
 +if(WITH_USD)
 +  list(APPEND __boost_packages python)

--- a/usd_python.patch
+++ b/usd_python.patch
@@ -1,26 +1,27 @@
 diff --git a/build_files/cmake/platform/platform_unix.cmake b/build_files/cmake/platform/platform_unix.cmake
-index ac570f17e47..505aa97934c 100644
+index bdf39d04d32..4322e0aa042 100644
 --- a/build_files/cmake/platform/platform_unix.cmake
 +++ b/build_files/cmake/platform/platform_unix.cmake
-@@ -320,6 +320,9 @@ if(WITH_BOOST)
-     if(WITH_OPENVDB)
-       list(APPEND __boost_packages iostreams)
-     endif()
-+    if(WITH_USD)
-+      list(APPEND __boost_packages python)
-+    endif()
-     list(APPEND __boost_packages system)
-     find_package(Boost 1.48 COMPONENTS ${__boost_packages})
-     if(NOT Boost_FOUND)
-diff --git a/source/blender/usd/CMakeLists.txt b/source/blender/usd/CMakeLists.txt
-index 6ea02f44d76..0ec18e17689 100644
+@@ -334,6 +334,10 @@ if(WITH_OPENVDB)
+   endif()
+ endif()
+ 
++if(WITH_USD)
++  list(APPEND __boost_packages python)
++endif()
++
+ if(WITH_NANOVDB)
+   find_package_wrapper(NanoVDB)
+   set_and_warn_library_found("NanoVDB" NANOVDB_FOUND WITH_NANOVDB)
+diff --git a/source/blender/io/usd/CMakeLists.txt b/source/blender/io/usd/CMakeLists.txt
+index ebd292782c0..02486e72461 100644
 --- a/source/blender/io/usd/CMakeLists.txt
 +++ b/source/blender/io/usd/CMakeLists.txt
-@@ -48,6 +48,7 @@ set(INC
+@@ -55,6 +55,7 @@ set(INC
  set(INC_SYS
    ${USD_INCLUDE_DIRS}
    ${BOOST_INCLUDE_DIR}
 +  ${PYTHON_INCLUDE_DIRS}
    ${TBB_INCLUDE_DIR}
+   ${PYTHON_INCLUDE_DIR}
  )
- 


### PR DESCRIPTION
`usd_python.patch` was out of date and would not match the content of `platform_unix.cmake` properly. This PR updates the patch and fixes the build.